### PR TITLE
Only exit early in case of larger size image if of same image type

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ module.exports = function (opts = {}) {
     debug(`green`, `new image width is probably ${newImageWidth}`)
 
     // return if image is smaller than newImageWidth
-    if (newImageWidth >= imageSize(originFilePath).width) {
+    if (newImageWidth >= imageSize(originFilePath).width && reqFileType === newFileType) {
       debug(`orange`, `origin image is smaller than new image width`)
       return next()
     }


### PR DESCRIPTION
If original image is less wide than the target width, but there's a file type conversion, the result may still be smaller than the original (e.g. jpg -> webp). This PR just modifies the size check to only apply if there's no file type change.