### PR TITLE
Resize with metadata to prevent EXIF loss

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ module.exports = function (opts = {}) {
 				// create and cache image
 				sharp(originFilePath)
 					.resize(cacheFileWidth)
+					.withMetadata()
 					.toFile(cacheFilePath, (err, info) => {
 						if (err) {
 							debug(`red`, `(${reqFileName}) sharp faild to create file: ${err}`)


### PR DESCRIPTION
Sharp().resize drops all the EXIF data on the image.
This is a problem as the correct image rotation is also lost.